### PR TITLE
Add daily journal calendar

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,6 +48,20 @@
         <br>
         <br>
         <div id="mensaje-muy-bien" style="display: none; font-size: 18px; color: rgb(193, 193, 203); text-align: center; margin-top: 20px;">¡Muy bien hecho!</div>
+
+        <div id="calendario-container">
+            <h2>Diario</h2>
+            <div id="calendario"></div>
+        </div>
+
+        <div id="diarioModal" class="modal" style="display:none;">
+            <div class="modal-contenido">
+                <h3 id="modalFecha"></h3>
+                <textarea id="diarioTexto" rows="10"></textarea><br>
+                <button id="guardarDiario">Guardar</button>
+                <button id="cancelarDiario">Cancelar</button>
+            </div>
+        </div>
     </main>
     <footer>
         <p>&copy; 2024 Ludin Guerra</p>

--- a/script.js
+++ b/script.js
@@ -112,6 +112,75 @@ document.addEventListener('DOMContentLoaded', function() {
     // Inicializa la barra con el estado guardado
     pulsosTotales = pulsosPorBoton.reduce((a, b) => a + b, 0);
     actualizarBarra();
+
+    /* === Diario === */
+    let fechaSeleccionada = '';
+
+    function generarCalendario() {
+        const contenedor = document.getElementById('calendario');
+        const hoy = new Date();
+        const anio = hoy.getFullYear();
+        const mes = hoy.getMonth();
+        const primerDia = new Date(anio, mes, 1).getDay();
+        const numDias = new Date(anio, mes + 1, 0).getDate();
+        contenedor.innerHTML = '';
+        const tabla = document.createElement('table');
+        const header = document.createElement('tr');
+        const diasSemana = ['Dom','Lun','Mar','Mie','Jue','Vie','Sab'];
+        diasSemana.forEach(d => {
+            const th = document.createElement('th');
+            th.textContent = d;
+            header.appendChild(th);
+        });
+        tabla.appendChild(header);
+
+        let fila = document.createElement('tr');
+        for (let i=0; i<primerDia; i++) {
+            fila.appendChild(document.createElement('td'));
+        }
+        for (let dia=1; dia<=numDias; dia++) {
+            if ((primerDia + dia - 1) % 7 === 0) {
+                tabla.appendChild(fila);
+                fila = document.createElement('tr');
+            }
+            const td = document.createElement('td');
+            td.textContent = dia;
+            td.className = 'dia-calendario';
+            td.addEventListener('click', () => abrirModal(anio, mes, dia));
+            fila.appendChild(td);
+        }
+        tabla.appendChild(fila);
+        contenedor.appendChild(tabla);
+    }
+
+    function abrirModal(a, m, d) {
+        fechaSeleccionada = `${a}-${String(m+1).padStart(2,'0')}-${String(d).padStart(2,'0')}`;
+        document.getElementById('modalFecha').textContent = fechaSeleccionada;
+        document.getElementById('diarioTexto').value = localStorage.getItem('diario-'+fechaSeleccionada) || '';
+        document.getElementById('diarioModal').style.display = 'flex';
+    }
+
+    function cerrarModal() {
+        document.getElementById('diarioModal').style.display = 'none';
+    }
+
+    function guardarDiario() {
+        const texto = document.getElementById('diarioTexto').value;
+        localStorage.setItem('diario-'+fechaSeleccionada, texto);
+        const blob = new Blob([texto], {type:'text/plain'});
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `diario-${fechaSeleccionada}.txt`;
+        a.click();
+        URL.revokeObjectURL(url);
+        cerrarModal();
+    }
+
+    document.getElementById('guardarDiario').addEventListener('click', guardarDiario);
+    document.getElementById('cancelarDiario').addEventListener('click', cerrarModal);
+
+    generarCalendario();
 });
 //   if (progreso <= 33) {
  //   color = `linear-gradient(to right, red ${progreso}%, transparent ${progreso}%)`;

--- a/styles.css
+++ b/styles.css
@@ -187,3 +187,49 @@ main {
     max-width: 800px; /* Ancho máximo del contenido principal */
 }
 
+#calendario-container {
+    margin-top: 20px;
+    text-align: center;
+}
+
+#calendario table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 0 auto;
+}
+
+#calendario th, #calendario td {
+    border: 1px solid #ffffff;
+    padding: 5px;
+    cursor: pointer;
+}
+
+#calendario td:hover {
+    background-color: rgba(30, 61, 89, 0.7);
+}
+
+.modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0,0,0,0.5);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.modal-contenido {
+    background-color: #ffffff;
+    color: #000000;
+    padding: 20px;
+    border-radius: 10px;
+    width: 300px;
+}
+
+.modal-contenido textarea {
+    width: 100%;
+    height: 150px;
+}
+


### PR DESCRIPTION
## Summary
- add diary calendar container and modal in HTML
- style calendar table and diary modal
- implement calendar generation and writing diary saving to localStorage and downloadable text files

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6844c0aa44808331afa1b8f2fcfb1a79